### PR TITLE
Trailer: deutsche TMDB-Videos per include_video_language laden

### DIFF
--- a/resources/lib/trailer.py
+++ b/resources/lib/trailer.py
@@ -1183,7 +1183,7 @@ def playTrailer(tmdb_id, mediatype='movie', title='', year='', poster='', pref_l
     tmdb_en = cTMDB(lang='en')  # EN for English title + IMDB ID
     en_data = None
     try:
-        term = 'append_to_response=videos'
+        term = 'append_to_response=videos&include_video_language=de,en,null'
         if url_type == 'tv':
             term += ',external_ids'
         en_data = tmdb_en.getUrl('%s/%s' % (url_type, tmdb_id), term=term)


### PR DESCRIPTION
TMDB `append_to_response=videos` liefert standardmaessig nur Videos
der angeforderten Sprache (en). Mit `include_video_language=de,en,null`
werden auch deutsche Trailer zurueckgegeben, die dann im [DE]-Block
korrekt gefiltert und bevorzugt abgespielt werden.

Getestet mit "Der weisse Hai" (1975) — vorher: nur englischer Trailer,
nachher: deutscher TMDB-Trailer wird gefunden und abgespielt.

Einzeiler-Fix in trailer.py Zeile 1186.